### PR TITLE
ticket6_symbolisation_pont_SQL

### DIFF
--- a/ticket_6 pont/codage pont avec commentaire.sql
+++ b/ticket_6 pont/codage pont avec commentaire.sql
@@ -1,0 +1,40 @@
+SELECT 
+    row_number() OVER () AS _uid_,  -- creation d'un ID unique pour chaque ligne finale
+    * 
+FROM (
+    WITH snapped AS (
+        SELECT
+            highway,  
+            ST_Snap(way, ST_Collect(way), 1) AS snapped_way  -- ST_Snap ajuste chaque ligne pour qu'elle s'aligne sur les autres à moins de 1 unité, cela aura pour effet: 
+			-- si deux lignes sont très proches (moins de 1 unité), leurs points finaux seront déplacés pour qu’elles se connectent parfaitement, éliminant les gaps ou décalages minimes
+        FROM planet_osm_line
+        WHERE bridge NOT IN ('0','no','')  -- On ne garde que les ponts actifs
+          AND highway IN ('path','cycleway','footway','pedestrian','steps','bridleway','boardwalk')
+        GROUP BY highway, way -- regroupe les lignes pour faire fonctionner le collect
+    ),  
+
+    clusters AS ( -- regroupement des lignes qui se touchent ou s'intersectent
+        SELECT
+            unnest(ST_ClusterIntersecting(snapped_way)) AS cluster_geom  -- ST_ClusterIntersecting crée des groupes de lignes connectées, au cas ou des lignes ne serait pas une seule ligne en provenant de osm
+            --  et unnest permet de transformer ces clusters en lignes individuelles pour traitement
+        FROM snapped
+    ),  
+
+    merged AS (-- fusion et nettoyage des lignes de chaque cluster
+        SELECT
+            row_number() OVER () AS geom_id,  -- ID unique pour chaque ligne fusionnée
+            ST_RemoveRepeatedPoints( -- va supprimer les points consécutifs identiques ou très proches (tolérance 0.001)
+                ST_LineMerge(ST_Union(cluster_geom)), 0.001 -- ST_LineMerge combine les segments en une seule ligne continue + ST_Union fusionne toutes les lignes d'un cluster
+            ) AS geom_clean, 
+            ST_Length(ST_LineMerge(ST_Union(cluster_geom))) AS length_way  -- Calcul de la longueur totale de la ligne fusionnée
+        FROM clusters
+        GROUP BY cluster_geom
+    )
+
+-- sélection finale des colonnes utiles
+    SELECT
+        geom_id,           -- Identifiant unique
+        geom_clean AS geom,  -- Géométrie finale nettoyée et fusionnée
+        length_way         -- Longueur de la ligne
+    FROM merged
+) AS _subq_1_

--- a/ticket_6 pont/svgsymbole.svg
+++ b/ticket_6 pont/svgsymbole.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="53.150177mm"
+   height="53.791225mm"
+   viewBox="0 0 53.150177 53.791225"
+   version="1.1"
+   id="svg1"
+   inkscape:export-filename="svgsymbole.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm">
+    <inkscape:page
+       x="0"
+       y="0"
+       width="53.150177"
+       height="53.791225"
+       id="page2"
+       margin="0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1">
+    <linearGradient
+       id="swatch9"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       id="swatch6"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#swatch9"
+       id="linearGradient9"
+       x1="93.090515"
+       y1="228.96608"
+       x2="143.26884"
+       y2="228.96608"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(91.604627,200.61234)" />
+  </defs>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-91.604627,-200.61234)">
+    <path
+       style="fill:none;fill-opacity:1;stroke:url(#linearGradient9);stroke-width:12.6;stroke-dasharray:none"
+       d="m 93.208384,253.58182 24.973586,-49.00476 24.969,49.00938"
+       id="path1"
+       inkscape:export-filename="symbole svg.svg"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
+  </g>
+</svg>


### PR DESCRIPTION

<img width="1911" height="1020" alt="Avant nouveau code SQL" src="https://github.com/user-attachments/assets/d5acf917-df04-476f-868b-bb56e82c94cb" />
<img width="1918" height="1021" alt="Avec nouveau code SQL" src="https://github.com/user-attachments/assets/86727854-5ae3-4be0-b60a-8312f8c51a6d" />

Voici l'amélioration d'un code qui permet l'utilisation d'un même symbole pour les deux différents types de ponts existants auparavant. Celui-ci permet la mise en place d'une seule ligne continue, et à l'aide du document svg les ponts seront symbolisés par le même symbole utilisé pour les ponts présents qui ont des longueurs plus faible (inférieur à 100m)