### PR TITLE
code_building_simplification

### DIFF
--- a/ticket_3_building simplification/building simplification code commenter.sql
+++ b/ticket_3_building simplification/building simplification code commenter.sql
@@ -1,0 +1,31 @@
+WITH clustered AS (
+    SELECT
+        way, -- Sélection des géométries de bâtiments
+        ST_ClusterDBSCAN(way, eps := 10, minpoints := 1) OVER () AS cid  -- Attribution d'un identifiant de cluster selon la proximité spatiale, eps = distance max entre deux batiments pour les considérer comme un même cluster 
+		-- et minpoint = un cluster peut etre formé même avec 1 seul élément.
+    FROM planet_osm_polygon
+    WHERE building IS NOT NULL  -- On conserve uniquement des polygones de bâtiments
+      AND way && ST_Transform(
+          ST_MakeEnvelope(5.63, 49.71, 5.68, 49.75, 4326), -- Limitation du traitement à la zone d'étude (ici à la commune de Habay)
+          3857
+      )
+)
+
+-- Fusion et généralisation des bâtiments par cluster
+SELECT
+    cid,
+    ST_Simplify( -- simplification des batiments finaux
+        ST_Union( -- fusion des batiments appartenant à un même cluster
+            ST_MakeValid(way) -- permet d'avoir des géometries valides
+        ),
+        1.5 -- en fonction de l'échelle, cette valeur peut changer, à l'échelle d'une ville on a une simplification qui reste précise 
+    ) AS geom
+
+FROM clustered
+
+-- Suppression des entités sans cluster
+WHERE cid IS NOT NULL
+
+-- Création d'un polygone final par cluster
+GROUP BY cid;
+


### PR DESCRIPTION
<img width="1917" height="1018" alt="Avant code de simplification" src="https://github.com/user-attachments/assets/5768961f-f48d-4b78-a6fb-1d4bc6f25c84" />

<img width="1916" height="1020" alt="Après code de simplification" src="https://github.com/user-attachments/assets/e27e709a-8826-4a2f-9b6a-d022a480baf5" />



Ici à l'aide de ce code, il est possible d'observer la fusion des bâtiments qui avant étaient séparés par de fines lignes blanches (voir image 1), sur l'image 2 avec les building en brun, on voit clairement que les buildings forment tous qu'une seule entité et ne sont plus séparé en plus d'être légèrement simplifier au niveau de leur forme. Il sont maintenant fusionnés pour ne former qu'un cluster . Deux choses à souligner: 1. La partie du code mettant une enveloppe en place peut totalement être supprimée pour travailler sur une échelle plus grande. 2. De plus, la valeur eps 10 peut aussi être modifiée en fonction de la distance recherchée entre les bâtiments,  ici à l'échelle de la ville d'Habay cela fonctionnait parfaitement.