### PR TITLE
Simplification du rendu des autoroutes et rails

### DIFF
--- a/ticket 2 investigation sur la simplification de la ligne d'autoroute et des rails/simplification autoroute et rail.sql
+++ b/ticket 2 investigation sur la simplification de la ligne d'autoroute et des rails/simplification autoroute et rail.sql
@@ -1,0 +1,96 @@
+--- ROAD
+
+WITH base AS (
+
+    -- Sélection des autoroutes avec une référence
+    SELECT
+        ST_Transform(way, 3857) AS geom,  -- Passage en projection métrique
+        ref                              -- Identifiant de l’axe routier
+    FROM planet_osm_line
+    WHERE highway = 'motorway'           -- Autoroutes uniquement
+      AND highway NOT LIKE '%_link'      -- Exclusion des bretelles
+      AND ref IS NOT NULL                -- Référence obligatoire
+),
+
+polygons AS (
+
+    -- Construction d’un polygone par référence routière
+    SELECT
+        ref,
+        ST_Subdivide( -- découpage des polygones trop grands ou complexes permettant de facilité les calculs
+            ST_UnaryUnion( -- tout les polygones collectionnés sont combinés en une seule géom (polygone) = création d'une forme continue
+                ST_Collect( -- regroupe les buffers en une seule collection = traite tout les segments de la route comme un ensemble
+                    ST_Buffer( -- création d'un buffer autour de chaque ligne (ici de 25m)
+                        ST_Simplify(geom, 2), -- Réduction de la complexité de la geom sans trop changer la forme originale
+                        25                    
+                    )
+                )
+            ),
+            5000 -- taille maximale des polygones subdivisés pour limiter la complexité
+        ) AS poly
+
+    FROM base
+    GROUP BY ref -- toute les geoms sont regroupés par ref routieres
+)
+
+-- Extraction de l’axe central des polygones
+SELECT
+    row_number() OVER () AS id,   -- Identifiant unique pour QGIS
+    ref,
+    ST_Transform( -- conversion de la projection en projection d'affichage 4326
+        ST_LineMerge( -- fusion des segments d’axe médian en une seule ligne continue
+            CG_ApproximateMedialAxis(poly) -- création d'une ligne centrale au milieu des polygones
+        ),
+        4326
+    ) AS geom
+FROM polygons
+
+-- Exclusion des géométries vides
+WHERE NOT ST_IsEmpty(poly);
+
+
+-----------------------------------------
+
+--- RAILWAYS
+
+WITH base AS (
+    SELECT
+        ST_Transform(way, 3857) AS geom,  -- transformation en projection métrique (Web Mercator) pour les calculs de distance
+        name                               -- selection du nom de la ligne ferroviaire
+    FROM planet_osm_line
+    WHERE railway = 'rail'               -- on ne garde que les rails
+      AND service IS NULL                -- exclusion des rails de service ou industriels + des tunnels + des ponts
+      AND (tunnel IS NULL OR tunnel = 'no')    
+      AND (bridge IS NULL OR bridge = 'no')  
+),  
+
+polygons AS (
+    SELECT
+        name,  -- regroupe par nom de ligne
+        ST_Subdivide(  -- decoupe les polygones trop gros ou complexes en morceaux plus petits pour faciliter les calculs
+            ST_UnaryUnion(  -- tout les polygones collectionnés sont combinés en une seule géom (polygone)
+                ST_Collect(  -- regroupe tous les buffers d’une même ligne en une collection
+                    ST_Buffer(  -- création d’un buffer autour de la ligne (ici 6m)
+                        ST_Simplify(geom, 1.5),  -- réduction de la complexité de la geom sans trop changer la forme originale
+                        6                          
+                    )
+                )
+            ),
+            3000  -- taille maximale des polygones subdivisés pour limiter la complexité
+        ) AS poly
+    FROM base
+    GROUP BY name
+)
+
+SELECT
+    row_number() OVER () AS id,  -- selection de l'id unique pour chaque ligne
+    name,                        -- selection du nom de la ligne ferroviaire
+    ST_Transform(                -- conversion en projection 4326 (latitude/longitude) pour la visualisation
+        ST_LineMerge(            -- fusion des segments d’axe médian en une seule ligne continue
+            CG_ApproximateMedialAxis(poly)  -- creation d'une ligne central au milieu des polygones
+        ),
+        4326
+    ) AS geom
+FROM polygons
+WHERE NOT ST_IsEmpty(poly)  -- On exclut les polygones vides (au cas où la fusion ou le buffer échoue)
+


### PR DESCRIPTION
<img width="1914" height="1022" alt="avant route et rails petite échelle" src="https://github.com/user-attachments/assets/b38445d4-21ca-4a43-bef8-4b3fabb00190" />
<img width="1915" height="1019" alt="après autoroute et rails petite échelle" src="https://github.com/user-attachments/assets/05b40d00-7c3b-4592-b136-cb1300245a47" />
<img width="1919" height="1020" alt="avant autoroute grande échelle" src="https://github.com/user-attachments/assets/f059f6b8-4469-4680-95e2-8674a27970a4" />
<img width="1918" height="1020" alt="Après autoroute grande échelle" src="https://github.com/user-attachments/assets/f244476a-f2ed-45bc-b43f-1ba7838698dc" />
<img width="1919" height="1020" alt="Avant rails grande échelle" src="https://github.com/user-attachments/assets/570cbe6d-9165-4280-9321-06dd349ef51d" />
<img width="1919" height="1024" alt="Après rails grande échelle" src="https://github.com/user-attachments/assets/a544459d-c278-4d38-ad20-d5ef86060d81" />




Ce code permet de simplifier le rendu des autoroutes et des rails sur OSM. On passe d'une géométries des autoroutes et rails qui utilisaient 2 MultiLineString (une dans un sens et une dans l'autre), à l'utilisation d'une seule Line pour représenter le chemin de fer et les autoroutes. Cependant, il faut souligner un élément qui n'a pas été possible de corriger c'est la prise en compte (en tout cas pour les rails) des ponts et des tunnels, étant donné qu'ils sont exclus, on ne les observe pas et il y a donc des trous aux endroits ou les rails passent sous des tunnels ou sur des ponts. Pour ce qui est des éléments à prendre en compte dans ce code ce sont les tailles des buffers, pour la route, la taille choisie est la taille minimale pour bien prendre en compte les 2 côtés des autoroutes même lors des échangeurs et pour les rails la taille peut encore varier en fonction de la prise en compte ou non de toute les voies d'une plus grosse gare par exemple.